### PR TITLE
Update bcm6358-t-com-speedport-w-303v.dts

### DIFF
--- a/target/linux/bcm63xx/dts/bcm6358-t-com-speedport-w-303v.dts
+++ b/target/linux/bcm63xx/dts/bcm6358-t-com-speedport-w-303v.dts
@@ -26,7 +26,7 @@
 
 		reset {
 			label = "reset";
-			gpios = <&pinctrl 11 0>;
+			gpios = <&pinctrl 11 1>;
 			linux,code = <KEY_RESTART>;
 			debounce-interval = <60>;
 		};


### PR DESCRIPTION
now OpenWrt boots regular, not failsafe anymore.  Reset button corrected.

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
